### PR TITLE
fix: avoid reassigning for-loop variables for Lua 5.5 compatibility

### DIFF
--- a/rimefiles/lua/filter_cand/tran_utf8_comment.lua
+++ b/rimefiles/lua/filter_cand/tran_utf8_comment.lua
@@ -7,6 +7,7 @@ local utf8_comment = require("filter_cand/utf8_comment")
 local function tran_utf8_comment(tran)
   for cand in tran:iter() do
     local cand_text = cand.text  -- cand.text ~= "" and cand.text or "〖空碼〗"
+    local cand = cand
     if utf8.len(cand_text) == 1 then
       cand = UniquifiedCandidate(cand, "uniq_unicode", cand_text, utf8_comment(cand_text) .. cand.comment)
     end

--- a/rimefiles/lua/filter_cand/tran_utf8_debug_comment.lua
+++ b/rimefiles/lua/filter_cand/tran_utf8_debug_comment.lua
@@ -16,6 +16,7 @@ local function tran_utf8_debug_comment(tran)
     --       and UniquifiedCandidate(cand, "uniq_unicode_debug", cand_text, debug_comment(cand) .. cand.comment) or
     --       cand
     --       )
+    local cand = cand
     if utf8.len(cand_text) == 1 then
       cand = UniquifiedCandidate(cand, "uniq_unicode_debug", cand_text, debug_comment(cand) .. utf8_comment(cand_text) .. cand.comment)
     else


### PR DESCRIPTION
In Lua 5.5, the control variable in for loops is read only. Two files reassigned `cand` inside `for cand in tran:iter()` loops, which caused rime.lua to fail entirely on load, breaking all modules.

Declare a local variable with the same name in the loop body.

Affected files:
- rimefiles/lua/filter_cand/tran_utf8_comment.lua
- rimefiles/lua/filter_cand/tran_utf8_debug_comment.lua

Ref:
- https://www.lua.org/manual/5.5/readme.html#changes
- https://www.lua.org/manual/5.5/manual.html (Section 8.1)